### PR TITLE
Lecture 104: `document` middleware (1/4 types of middleware in Mongoose)

### DIFF
--- a/models/tourModel.js
+++ b/models/tourModel.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose')
+const slugify = require('slugify')
 
 const tourSchema = new mongoose.Schema({
   name: {
@@ -7,6 +8,7 @@ const tourSchema = new mongoose.Schema({
     unique: true,
     trim: true 
   },
+  slug: String,
   duration: {
     type: Number,
     required: [true, 'A tour must have a duration.']
@@ -60,6 +62,25 @@ const tourSchema = new mongoose.Schema({
 tourSchema.virtual('durationWeeks').get(function() {
   return this.duration / 7  // `this` keyword will point to CURRENT Document
 })
+
+
+// DOCUMENT MIDDLEWARE: runs BEFORE .save() and .create()    (NOT AFFECTED for .insert())
+tourSchema.pre('save', function(next) {
+  // console.log(this) // `this` - point to currently process document
+
+  this.slug = slugify(this.name, { lower: true })
+  next()
+})
+
+// tourSchema.pre('save', function(next) {
+//   console.log('Will save document...')
+//   next()
+// })
+
+// tourSchema.post('save', function(doc, next) { // `doc` - the document just saved right before
+//   console.log(doc)
+//   next()
+// })
 
 const Tour = mongoose.model('Tour', tourSchema)
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "mongoose": "^5.9.6",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "slugify": "^1.4.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",


### PR DESCRIPTION
Keypoints:
I. There are 4 types of middleware in Mongoose:
    1/ Document
    2/ Query
    3/ Aggregate
    4/ Model

II. Package for creating slug for URL: `slugify`
    $ npm i slugify